### PR TITLE
Add redux persist and get item list saga

### DIFF
--- a/backend/setup/Swappee .postman_environment.json
+++ b/backend/setup/Swappee .postman_environment.json
@@ -1,0 +1,14 @@
+{
+	"id": "7d139408-a423-45b6-8915-f819bb161d04",
+	"name": "Swappee ",
+	"values": [
+		{
+			"key": "SwappeeUrl",
+			"value": "http://localhost:8022/swappee",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2021-12-24T08:48:03.560Z",
+	"_postman_exported_using": "Postman/9.5.0"
+}

--- a/backend/setup/Swappee.postman_collection.json
+++ b/backend/setup/Swappee.postman_collection.json
@@ -1,0 +1,750 @@
+{
+	"info": {
+		"_postman_id": "4614ace9-62a7-4359-8375-1efb42aa8aed",
+		"name": "Swappee",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Security",
+			"item": [
+				{
+					"name": "createAuthenticationToken",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var data = pm.response.json();\r",
+									"console.log(data.token);\r",
+									"pm.globals.set(\"token\", data.token);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"username\": \"MarcusTXK\",\r\n    \"password\": \"test\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/login/authenticate",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"login",
+								"authenticate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createAuthenticationToken Biscuit",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var data = pm.response.json();\r",
+									"console.log(data.token);\r",
+									"pm.globals.set(\"token\", data.token);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"username\": \"Biscuit2015\",\r\n    \"password\": \"test\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/login/authenticate",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"login",
+								"authenticate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createAuthenticationToken NewGuy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var data = pm.response.json();\r",
+									"console.log(data.token);\r",
+									"pm.globals.set(\"token\", data.token);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"username\": \"NewGuy\",\r\n    \"password\": \"testing123\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/login/authenticate",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"login",
+								"authenticate"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "refreshAndGetAuthenticationToken",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/login/refresh",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"login",
+								"refresh"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "ItemPublicApiController",
+			"item": [
+				{
+					"name": "getItem",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/public/item/4",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"public",
+								"item",
+								"4"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "getAll",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/public/item/list",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"public",
+								"item",
+								"list"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "findItemsByUserId",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/public/item/user/1",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"public",
+								"item",
+								"user",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "PicturePublicApiController",
+			"item": [
+				{
+					"name": "download",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/public/picture/12",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"public",
+								"picture",
+								"12"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "findByItemId",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/public/picture/item/15",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"public",
+								"picture",
+								"item",
+								"15"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "noauth"
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "UserPublicApiController",
+			"item": [
+				{
+					"name": "getUser",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/public/user/MarcusTXK",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"public",
+								"user",
+								"MarcusTXK"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "displayAvatar",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/public/user/2/avatar",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"public",
+								"user",
+								"2",
+								"avatar"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createUser",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "userDTO",
+									"value": "{\n\t\"id\": \"\",\n\t\"firstName\": \"New Guy\",\n\t\"lastName\": \"Tang\",\n\t\"username\": \"NewGuy\",\n\t\"password\": \"test\",\n\t\"email\": \"Guy@gmail\",\n\t\"avatar\": null,\n\t\"phone\": 98787397,\n\t\"emailOnly\": false,\n\t\"score\": 0,\n\t\"totalTraded\": 0\n}",
+									"type": "text"
+								},
+								{
+									"key": "avatar",
+									"type": "file",
+									"src": "/C:/Users/Marcus Tang/Pictures/ProfilePics/Charmander.jpg"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/public/user/",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"public",
+								"user",
+								""
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "noauth"
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "ItemPrivateApiController",
+			"item": [
+				{
+					"name": "getItem",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/private/item/4",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"private",
+								"item",
+								"4"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "itemLiked",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/private/item/1/true",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"private",
+								"item",
+								"1",
+								"true"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "findItemsByUserLikes",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/private/item/likes",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"private",
+								"item",
+								"likes"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "createItem",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "itemDTO",
+									"value": "{\n\t\"id\": \"null\",\n\t\"userId\": \"1\",\n\t\"status\": \"OPEN\",\n\t\"name\": \"Samsung Galaxy Note 10+\",\n\t\"description\": \"Its big\",\n\t\"brand\": \"Samsung\",\n\t\"new\": \"false\",\n\t\"category\": \"Phones\",\n\t\"strict\": \"true\",\n\t\"likes\": \"2\",\n\t\"preferredCats\": [\"Phone\", \"Game\", \"Car\"],\n\t\"preferredItems\": [{\n\t\t\"name\": \"1\",\n\t\t\"category\": \"1\",\n\t\t\"brand\": \"1\",\n\t\t\"new\": \"true\"\n\t}, {\n\t\t\"name\": \"2\",\n\t\t\"category\": \"2\",\n\t\t\"brand\": \"2\",\n\t\t\"new\": \"true\"\n\t}],\n\t\"itemHistory\": []\n}",
+									"type": "text"
+								},
+								{
+									"key": "photos",
+									"type": "file",
+									"src": "/C:/Users/Marcus Tang/Pictures/ProfilePics/Charmander original.png"
+								},
+								{
+									"key": "descriptions",
+									"value": "postman, postman2",
+									"type": "text"
+								},
+								{
+									"key": "photos",
+									"type": "file",
+									"src": "/C:/Users/Marcus Tang/Pictures/ProfilePics/Charmander.jpg"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/private/item",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"private",
+								"item"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateItem",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "itemDTO",
+									"value": "{\n\t\"id\": \"19\",\n\t\"userId\": \"1\",\n\t\"status\": \"OPEN\",\n\t\"name\": \"updated Samsung Galaxy Note 10+\",\n\t\"description\": \"Its big\",\n\t\"brand\": \"Samsung\",\n\t\"new\": \"false\",\n\t\"category\": \"Phones\",\n\t\"strict\": \"true\",\n\t\"likes\": \"2\",\n\t\"preferredCats\": [\"Phone\", \"Game\", \"Car\"],\n\t\"preferredItems\": [{\n\t\t\"name\": \"1\",\n\t\t\"category\": \"1\",\n\t\t\"brand\": \"1\",\n\t\t\"new\": \"true\"\n\t}, {\n\t\t\"name\": \"2\",\n\t\t\"category\": \"2\",\n\t\t\"brand\": \"2\",\n\t\t\"new\": \"true\"\n\t}],\n\t\"itemHistory\": []\n}",
+									"type": "text"
+								},
+								{
+									"key": "photos",
+									"type": "file",
+									"src": "PostManTest.png"
+								},
+								{
+									"key": "descriptions",
+									"value": "updated",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/private/item/2",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"private",
+								"item",
+								"2"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteItem",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "itemDTO",
+									"value": "{\n\t\"id\": \"null\",\n\t\"userId\": \"1\",\n\t\"status\": \"OPEN\",\n\t\"name\": \"Samsung Galaxy Note 10+\",\n\t\"description\": \"Its big\",\n\t\"brand\": \"Samsung\",\n\t\"new\": \"false\",\n\t\"category\": \"Phones\",\n\t\"strict\": \"true\",\n\t\"likes\": \"2\",\n\t\"preferredCats\": [\"Phone\", \"Game\", \"Car\"],\n\t\"preferredItems\": [{\n\t\t\"name\": \"1\",\n\t\t\"category\": \"1\",\n\t\t\"brand\": \"1\",\n\t\t\"new\": \"true\"\n\t}, {\n\t\t\"name\": \"2\",\n\t\t\"category\": \"2\",\n\t\t\"brand\": \"2\",\n\t\t\"new\": \"true\"\n\t}],\n\t\"itemHistory\": [{\n\t\t\t\"prevOwnerUsername\": \"MarcusTXK\",\n\t\t\t\"tradedItemId\": \"1\",\n\t\t\t\"tradedItemName\": \"1\"\n\t\t},\n\t\t{\n\t\t\t\"prevOwnerUsername\": \"MarcusTXK\",\n\t\t\t\"tradedItemId\": \"2\",\n\t\t\t\"tradedItemName\": \"2\"\n\t\t}\n\t]\n}",
+									"type": "text",
+									"disabled": true
+								},
+								{
+									"key": "photos",
+									"type": "file",
+									"src": "PostManTest.png",
+									"disabled": true
+								},
+								{
+									"key": "descriptions",
+									"value": "postman",
+									"type": "text",
+									"disabled": true
+								}
+							]
+						},
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/private/item/1",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"private",
+								"item",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "UserPrivateApiController",
+			"item": [
+				{
+					"name": "getUser",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/private/user/5",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"private",
+								"user",
+								"5"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "updateUser",
+					"request": {
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "userDTO",
+									"value": "{\n\t\"id\": \"5\",\n\t\"firstName\": \"New Guy\",\n\t\"lastName\": \"updated Tang\",\n\t\"username\": \"NewGuy\",\n\t\"password\": \"testing123\",\n\t\"email\": \"Guy@gmail\",\n\t\"avatar\": null,\n\t\"phone\": 98787397,\n\t\"emailOnly\": false,\n\t\"score\": 0,\n\t\"totalTraded\": 0\n}",
+									"type": "text"
+								},
+								{
+									"key": "avatar",
+									"type": "file",
+									"src": "/C:/Users/Marcus Tang/Pictures/ProfilePics/Charmander original.png"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/private/user/5",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"private",
+								"user",
+								"5"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "deleteUser",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "userDTO",
+									"value": "{\n\t\"id\": \"5\",\n\t\"firstName\": \"New Guy\",\n\t\"lastName\": \"updated Tang\",\n\t\"username\": \"NewGuy\",\n\t\"password\": \"\",\n\t\"email\": \"Guy@gmail\",\n\t\"avatar\": null,\n\t\"phone\": 98787397,\n\t\"emailOnly\": false,\n\t\"score\": 0,\n\t\"totalTraded\": 0\n}",
+									"type": "text",
+									"disabled": true
+								},
+								{
+									"key": "avatar",
+									"type": "file",
+									"src": "/C:/Users/Marcus Tang/Pictures/ProfilePics/Charmander original.png",
+									"disabled": true
+								}
+							]
+						},
+						"url": {
+							"raw": "{{SwappeeUrl}}/api/private/user/5",
+							"host": [
+								"{{SwappeeUrl}}"
+							],
+							"path": [
+								"api",
+								"private",
+								"user",
+								"5"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{token}}",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"pm.test (\"Status Code is 200\", function() {",
+					"    pm.response.to.have.status(200)",
+					"})"
+				]
+			}
+		}
+	]
+}

--- a/frontend/config/api.ts
+++ b/frontend/config/api.ts
@@ -13,6 +13,7 @@ export const API = create({
 
 export const ROUTES = {
   LOGIN: `/api/login/authenticate/`,
+  GET_ITEM_LIST: `/api/public/item/list`,
 };
 
 API.axiosInstance.interceptors.response.use(

--- a/frontend/config/store.ts
+++ b/frontend/config/store.ts
@@ -1,23 +1,39 @@
-import { applyMiddleware, createStore, Middleware, StoreEnhancer } from 'redux';
+import { applyMiddleware, createStore, Middleware, StoreEnhancer, Store } from 'redux';
 import createSagaMiddleware from 'redux-saga';
 import { createWrapper } from 'next-redux-wrapper';
-
+import { persistStore, persistReducer, Persistor } from 'redux-persist';
+import storage from 'redux-persist/lib/storage'; // defaults to localStorage for web
 import rootReducer from 'redux-saga/reducer';
 import rootSaga from 'redux-saga/saga';
 
 const bindMiddleware = (middleware: Middleware[]): StoreEnhancer => {
-  // if (process.env.NODE_ENV !== 'production') {
-  //   const { composeWithDevTools } = require('redux-devtools-extension');
-  //   return composeWithDevTools(applyMiddleware(...middleware));
-  // }
   return applyMiddleware(...middleware);
 };
 
+export interface StoreProperties {
+  persistor?: Persistor;
+}
+
 export const makeStore = () => {
   const sagaMiddleware = createSagaMiddleware();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const store: any = createStore(rootReducer, bindMiddleware([sagaMiddleware]));
-  store.sagaTask = sagaMiddleware.run(rootSaga);
+  let store: Store & StoreProperties;
+  const isServer = typeof window === 'undefined';
+
+  if (isServer) {
+    // If it's on server side, create a store
+    store = createStore(rootReducer, bindMiddleware([sagaMiddleware]));
+    sagaMiddleware.run(rootSaga);
+    return store;
+  }
+
+  const persistConfig = {
+    key: 'root',
+    storage,
+  };
+  const persistedReducer = persistReducer(persistConfig, rootReducer);
+  store = createStore(persistedReducer, bindMiddleware([sagaMiddleware]));
+  store.persistor = persistStore(store);
+  sagaMiddleware.run(rootSaga);
   return store;
 };
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,14 +11,15 @@
   "dependencies": {
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
-    "apisauce": "^2.1.1",
     "@material-ui/lab": "^4.0.0-alpha.60",
+    "apisauce": "^2.1.1",
     "next": "11.1.0",
     "next-redux-wrapper": "^7.0.4",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-responsive-carousel": "^3.2.22",
     "react-redux": "^7.2.5",
+    "react-responsive-carousel": "^3.2.22",
+    "redux-persist": "^6.0.0",
     "redux-saga": "^1.1.3",
     "sass": "^1.38.0"
   },

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -2,11 +2,16 @@ import { useEffect } from 'react';
 import type { AppProps } from 'next/app';
 import { ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { wrapper } from 'config/store';
+import { PersistGate } from 'redux-persist/integration/react';
+import { Store } from 'redux';
+import { useStore } from 'react-redux';
+
+import { wrapper, StoreProperties } from 'config/store';
 import theme from 'config/theme';
 import 'styles/scss/style.scss';
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
+  const store: Store & StoreProperties = useStore();
   useEffect(() => {
     // Remove the server-side injected CSS.
     const jssStyles = document.querySelector('#jss-server-side');
@@ -14,12 +19,13 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
       jssStyles.parentElement!.removeChild(jssStyles);
     }
   }, []);
-
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <Component {...pageProps} />
-    </ThemeProvider>
+    <PersistGate loading={null} persistor={store.persistor!}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Component {...pageProps} />
+      </ThemeProvider>
+    </PersistGate>
   );
 };
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Button, Box } from '@material-ui/core';
 import MCarousel from 'components/molecules/MCarousel';
 import Link from 'next/link';
 import Head from 'next/head';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 import { AppState } from 'redux-saga/interfaces';
+import { getItemList } from 'redux-saga/actions';
 import AContainer1440 from 'components/atoms/AContainer1440';
 import MCategoriesSection from 'components/molecules/MCategoriesSection';
 import MItemListingContainer from 'components/molecules/MItemListingContainer';
@@ -17,7 +18,12 @@ const Home = () => {
   const [isLogin, setLogin] = useState(false);
   const {
     user: { token },
+    items,
   } = useSelector((state: AppState) => state);
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(getItemList());
+  }, []);
 
   return (
     <>
@@ -70,6 +76,7 @@ const Home = () => {
         handleForgotPassword={() => console.log('Forgot Password')}
         handleSignup={() => console.log('Sign Up')}
       />
+      {console.log(items)}
     </>
   );
 };

--- a/frontend/redux-saga/actions.ts
+++ b/frontend/redux-saga/actions.ts
@@ -24,3 +24,23 @@ export function loginFailed(error: data.Error): actions.LoginFailed {
     error,
   };
 }
+
+export function getItemList(): actions.GetItemList {
+  return {
+    type: actionTypes.GET_ITEM_LIST,
+  };
+}
+
+export function getItemListSuccess(itemListData: data.GetItemListData): actions.GetItemListSuccess {
+  return {
+    type: actionTypes.GET_ITEM_LIST_SUCCESS,
+    data: itemListData,
+  };
+}
+
+export function getItemListFailed(error: data.Error): actions.GetItemListFailed {
+  return {
+    type: actionTypes.GET_ITEM_LIST_FAILED,
+    error,
+  };
+}

--- a/frontend/redux-saga/interfaces/actions.interfaces.ts
+++ b/frontend/redux-saga/interfaces/actions.interfaces.ts
@@ -6,6 +6,10 @@ export enum actionTypes {
   LOGIN = 'LOGIN',
   LOGIN_SUCCESS = 'LOGIN_SUCCESS',
   LOGIN_FAILED = 'LOGIN_FAILED',
+
+  GET_ITEM_LIST = 'GET_ITEM_LIST',
+  GET_ITEM_LIST_SUCCESS = 'GET_ITEM_LIST_SUCCESS',
+  GET_ITEM_LIST_FAILED = 'GET_ITEM_LIST_FAILED',
 }
 
 export interface Login {
@@ -23,4 +27,18 @@ export interface LoginFailed {
   error: data.Error;
 }
 
-export type Action = Login | LoginSuccess | LoginFailed;
+export interface GetItemList {
+  type: actionTypes.GET_ITEM_LIST;
+}
+
+export interface GetItemListSuccess {
+  type: actionTypes.GET_ITEM_LIST_SUCCESS;
+  data: data.GetItemListData;
+}
+
+export interface GetItemListFailed {
+  type: actionTypes.GET_ITEM_LIST_FAILED;
+  error: data.Error;
+}
+
+export type Action = Login | LoginSuccess | LoginFailed | GetItemList | GetItemListSuccess | GetItemListFailed;

--- a/frontend/redux-saga/interfaces/data.interfaces.ts
+++ b/frontend/redux-saga/interfaces/data.interfaces.ts
@@ -2,13 +2,38 @@ export interface LoginData {
   token: string;
 }
 
+export interface ItemData {
+  id: number;
+  imagePath: number;
+  name: string;
+  status: string;
+  brand: string;
+  description: string;
+  likes: number;
+  liked: boolean;
+  userId: number;
+  userName: string;
+  avatarPath?: number;
+  createdDate: string;
+  lastModifiedDate: string;
+  new: true;
+}
+
+export interface GetItemListData {
+  message: string;
+  isSuccess: boolean;
+  data: ItemData[];
+}
+
 export interface Error {
   message?: string;
+  isSuccess?: boolean;
+  data?: unknown;
 }
 
 export interface AppState {
   error: null | Error;
   user: LoginData;
-
+  items: ItemData[];
   isLoginLoading: boolean;
 }

--- a/frontend/redux-saga/reducer.ts
+++ b/frontend/redux-saga/reducer.ts
@@ -1,11 +1,12 @@
 import { HYDRATE } from 'next-redux-wrapper';
-import { AppState, Action, actionTypes } from './interfaces';
+import { AppState, Action, actionTypes, ItemData } from './interfaces';
 
 const initialState: AppState = {
   error: null,
   user: {
     token: '',
   },
+  items: [],
 
   isLoginLoading: false,
 };
@@ -26,6 +27,12 @@ const reducer = (state = initialState, action: Action | { type: typeof HYDRATE; 
         ...state,
         ...{ error: action.error, isLoginLoading: false },
       };
+
+    case actionTypes.GET_ITEM_LIST_SUCCESS:
+      return { ...state, items: action.data.data };
+
+    case actionTypes.GET_ITEM_LIST_FAILED:
+      return { ...state, error: action.error };
 
     default:
       return state;

--- a/frontend/redux-saga/saga.ts
+++ b/frontend/redux-saga/saga.ts
@@ -1,19 +1,21 @@
 import { call, put, takeLatest } from 'redux-saga/effects';
 import { ROUTES, API } from '../config/api';
-import { loginSuccess, loginFailed } from './actions';
+import { loginSuccess, loginFailed, getItemListSuccess, getItemListFailed } from './actions';
 import { actionTypes, Login } from './interfaces';
 
 function* loginSaga(action: Login) {
   const { data, ok } = yield call(() => API.post(ROUTES.LOGIN, action.payload));
-  if (ok) {
-    yield put(loginSuccess(data));
-  } else {
-    yield put(loginFailed(data));
-  }
+  yield put(ok ? loginSuccess(data) : loginFailed(data));
+}
+
+function* getItemListSaga() {
+  const { data, ok } = yield call(() => API.get(ROUTES.GET_ITEM_LIST));
+  yield put(ok ? getItemListSuccess(data) : getItemListFailed(data));
 }
 
 function* rootSaga(): Generator {
   yield takeLatest(actionTypes.LOGIN, loginSaga);
+  yield takeLatest(actionTypes.GET_ITEM_LIST, getItemListSaga);
 }
 
 export default rootSaga;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3276,6 +3276,11 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-saga@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-1.1.3.tgz#9f3e6aebd3c994bbc0f6901a625f9a42b51d1112"


### PR DESCRIPTION
# Description

* Add redux persist to persist data on refresh
* Add get item list saga
* Add postman tests and scripts

Note: When building, the error `redux-persist failed to create sync storage. falling back to memory storage.` will occur, but it can be ignored as it does not affect anything. This is due to a Next,js and redux persist conflict that occurs during SSR that I will fix in the future.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Screenshot
Please include a screenshot of the change if relevant. Please delete this section if not relevant.

# How Has This Been Tested?
Currently, when the main page is loaded, the item list will be fetched from the backend and console.log will output the list. The main page will be updated in the future to render it.
![image](https://user-images.githubusercontent.com/50147457/147341033-54ed4478-e9b5-4c63-b62e-9e98e87b0149.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
